### PR TITLE
Organizational updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 If this is a pull request for a new release, please use the release template:
-   https://github.com/asfadmin/hyp3-rtc-gamma/compare/master...develop?template=release.md
+   https://github.com/ASFHyP3/hyp3-rtc-gamma/compare/master...develop?template=release.md
  
 NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
 changes which you'd like reviewed. Do not open a pull request to update a feature or personal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,11 @@ jobs:
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: docker://antonyurchenko/git-release:latest
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: HyP3 RTC GAMMA ${{ github.ref }}
+          ALLOW_TAG_PREFIX: "true"
+          RELEASE_NAME_PREFIX: HyP3 RTC GAMMA
 
       - name: Attempt fast-forward develop from master
         run: |
@@ -41,4 +40,5 @@ jobs:
           pr_assignee: ${{ github.actor }}
           pr_label: tools-bot
           pr_draft: false
+          pr_allow_empty: true
           github_token: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           query: .github/queries/asssociated-pr.query.yml
           outputFile: pr.json
-          owner: asfadmin
+          owner: ASFHyP3
           name: hyp3-rtc-gamma
           sha: ${{ github.sha }}
 
@@ -76,7 +76,7 @@ jobs:
         with:
           query: .github/queries/pr-labels.query.yml
           outputFile: labels.json
-          owner: asfadmin
+          owner: ASFHyP3
           name: hyp3-rtc-gamma
 
       - name: Upload a Build Artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2.0.3](https://github.com/asfadmin/hyp3-rtc-gamma/compare/v2.0.2...v2.0.3)
+## [2.0.3](https://github.com/ASFHyP3/hyp3-rtc-gamma/compare/v2.0.2...v2.0.3)
 
 ## Fixed
 * Updates the minimum required `hyp3lib` and `hyp3proclib` version to bring in the
-  [`get_dem.py` NoData bugfix](https://github.com/asfadmin/hyp3-lib/pull/175) and
+  [`get_dem.py` NoData bugfix](https://github.com/ASFHyP3/hyp3-lib/pull/175) and
   the [`default_rtc_resolution` bugfix](https://github.com/asfadmin/hyp3-proc-lib/pull/4),
   respectively
 
-## [v2.0.2](https://github.com/asfadmin/hyp3-rtc-gamma/compare/v2.0.1...v2.0.2)
+## [2.0.2](https://github.com/ASFHyP3/hyp3-rtc-gamma/compare/v2.0.1...v2.0.2)
 
 ### Changed
 * The v2 entrypoint will now make up to three retry attempts if it fails to download the input granule from the ASF archive.
 * Changed the name of the product README file to `<product_name>.README.txt`, e.g. `S1A_IW_RT30_20170708T161200_G_gpn.README.txt`
 * Calls to mk_geo_radcal will no longer include the `-j do not use layover-shadow map in the calculation of pixel_area` flag.  The layover-shadow map will now be consistently applied to all products.
-* Upgraded to [hyp3-lib v1.2.2](https://github.com/asfadmin/hyp3-lib/blob/develop/CHANGELOG.md#v122)
+* Upgraded to [hyp3-lib v1.2.2](https://github.com/ASFHyP3/hyp3-lib/blob/develop/CHANGELOG.md#v122)
 * Removed custom blank_bad_data.py from mk_geo_radcal processing.  Border pixels for older GRD products are now cleaned using the default `make_edge` setting of `par_S1_GRD`.
 
-## [v2.0.1](https://github.com/asfadmin/hyp3-rtc-gamma/compare/v2.0.0...v2.0.1)
+## [2.0.1](https://github.com/ASFHyP3/hyp3-rtc-gamma/compare/v2.0.0...v2.0.1)
 
 ### Changed
 * hyp3-v2 output products are now packaged in a .zip file similar to hyp3-v1 products
 
-## [v2.0.0](https://github.com/asfadmin/hyp3-rtc-gamma/compare/v1.3.1...v2.0.0)
+## [2.0.0](https://github.com/ASFHyP3/hyp3-rtc-gamma/compare/v1.3.1...v2.0.0)
 
 This is a significant refactor of `hyp3-rtc-gamma` into:
 * A `pip` installable package called `hyp3_rtc_gamma`

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ LABEL org.opencontainers.image.description="HyP3 plugin for radiometric terrain 
 LABEL org.opencontainers.image.vendor="Alaska Satellite Facility"
 LABEL org.opencontainers.image.authors="ASF APD/Tools Team <uaf-asf-apd@alaska.edu>"
 LABEL org.opencontainers.image.licenses="BSD-3-Clause"
-LABEL org.opencontainers.image.url="https://github.com/asfadmin/hyp3-rtc-gamma"
-LABEL org.opencontainers.image.source="https://github.com/asfadmin/hyp3-rtc-gamma"
+LABEL org.opencontainers.image.url="https://github.com/ASFHyP3/hyp3-rtc-gamma"
+LABEL org.opencontainers.image.source="https://github.com/ASFHyP3/hyp3-rtc-gamma"
 # LABEL org.opencontainers.image.documentation=""
 
 # Dynamic lables to define at build time via `docker build --label`

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description=long_desc,
     long_description_content_type='text/markdown',
 
-    url='https://github.com/asfadmin/hyp3-rtc-gamma',
+    url='https://github.com/ASFHyP3/hyp3-rtc-gamma',
 
     author='ASF APD/Tools Team',
     author_email='uaf-asf-apd@alaska.edu',


### PR DESCRIPTION
* Change all references of `asfadmin` github org to new `ASFHyP3` org
* Update the release workflow to use the `CHANGELOG.md` when writing the release notes
  * Removes the `v` prefix on version numbers inside the `CHANGELOG.md` as `antonyurchenko/git-release` can only handle prefixes on git tags and not within the `CHANGELOG.md`