### PR TITLE
draft of --include-scattering-area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [unreleased]
 
 ### Added
-* A new `--include-scattering-area` option has been added to `rtc_sentinel.py` and `hyp3_rtc_gamma_v2` to include a geotiff of scattering area in the product package.  This supports creation of composites of RTC images using Local Resolution Weighting per https://ieeexplore.ieee.org/document/6350465.
+* A new `--include-scattering-area` option has been added to `rtc_sentinel.py` and `hyp3_rtc_gamma_v2` to include a geotiff of scattering area in the product package.  This supports creation of composites of RTC images using Local Resolution Weighting per Small (2012) https://doi.org/10.1109/IGARSS.2012.6350465.
 
 ### Removed
 * `rtc_sentinel.py` no longer creates a flattened backscatter image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+* A new `--include-scattering-area` option has been added to `rtc_sentinel.py` and `hyp3_rtc_gamma_v2` to include a geotiff of scattering area in the product package.  This supports creation of composites of RTC images using Local Resolution Weighting per https://ieeexplore.ieee.org/document/6350465.
+
+### Removed
+* `rtc_sentinel.py` no longer creates a flattened backscatter image
+
 ## [2.3.4](https://github.com/ASFHyP3/hyp3-rtc-gamma/compare/v2.3.3...v2.3.4)
 
 ### Changed

--- a/hyp3_rtc_gamma/__main__.py
+++ b/hyp3_rtc_gamma/__main__.py
@@ -61,6 +61,7 @@ def main_v2():
     parser.add_argument('--dem-matching', type=string_is_true, default=False)
     parser.add_argument('--include-dem', type=string_is_true, default=False)
     parser.add_argument('--include-inc-map', type=string_is_true, default=False)
+    parser.add_argument('--include-area-map', type=string_is_true, default=False)
     parser.add_argument('granule')
     args = parser.parse_args()
 
@@ -79,6 +80,7 @@ def main_v2():
                         pwr_flag=(args.scale == 'power'),
                         gamma_flag=(args.radiometry == 'gamma0'),
                         filter_flag=args.speckle_filter,
+                        include_area_map=args.include_area_map,
                     )
 
     if not args.include_dem:

--- a/hyp3_rtc_gamma/__main__.py
+++ b/hyp3_rtc_gamma/__main__.py
@@ -61,7 +61,7 @@ def main_v2():
     parser.add_argument('--dem-matching', type=string_is_true, default=False)
     parser.add_argument('--include-dem', type=string_is_true, default=False)
     parser.add_argument('--include-inc-map', type=string_is_true, default=False)
-    parser.add_argument('--include-area-map', type=string_is_true, default=False)
+    parser.add_argument('--include-scattering-area', type=string_is_true, default=False)
     parser.add_argument('granule')
     args = parser.parse_args()
 
@@ -80,7 +80,7 @@ def main_v2():
                         pwr_flag=(args.scale == 'power'),
                         gamma_flag=(args.radiometry == 'gamma0'),
                         filter_flag=args.speckle_filter,
-                        include_area_map=args.include_area_map,
+                        include_scattering_area=args.include_scattering_area,
                     )
 
     if not args.include_dem:

--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -155,7 +155,7 @@ def reproject_dir(dem_type, res, prod_dir=None):
 
 
 def report_kwargs(in_name, out_name, res, dem, roi, shape, match_flag, dead_flag, gamma_flag,
-                  pwr_flag, filter_flag, looks, terms, par, no_cross_pol, smooth, area, orbit_file):
+                  pwr_flag, filter_flag, looks, terms, par, no_cross_pol, smooth, include_area_map, orbit_file):
     logging.info("Parameters for this run:")
     logging.info("    Input name                        : {}".format(in_name))
     logging.info("    Output name                       : {}".format(out_name))
@@ -176,12 +176,12 @@ def report_kwargs(in_name, out_name, res, dem, roi, shape, match_flag, dead_flag
         logging.info("    Offset file                       : {}".format(par))
     logging.info("    Process crosspol                  : {}".format(not no_cross_pol))
     logging.info("    Smooth DEM tiles                  : {}".format(smooth))
-    logging.info("    Save Pixel Area                   : {}".format(area))
+    logging.info("    Include Area Map                  : {}".format(include_area_map))
     logging.info("    Orbit File                        : {}".format(orbit_file))
 
 
 def process_pol(in_file, rtc_name, out_name, pol, res, look_fact, match_flag, dead_flag, gamma_flag,
-                filter_flag, pwr_flag, browse_res, dem, terms, par=None, area=False, orbit_file=None):
+                filter_flag, pwr_flag, browse_res, dem, terms, par=None, orbit_file=None):
     logging.info(f'Processing the {pol} polarization')
 
     mgrd = "{out}.{pol}.mgrd".format(out=out_name, pol=pol)
@@ -247,17 +247,9 @@ def process_pol(in_file, rtc_name, out_name, pol, res, look_fact, match_flag, de
 
     os.chdir(geo_dir)
 
-    # Divide sigma0 by sin(theta) to get beta0
-    execute(f"float_math image_0.inc_map - image_1.sin_theta {width} 7 - - 1 1 - 0")
-
-    execute(f"float_math image_cal_map.mli image_1.sin_theta image_1.beta {width} 3 - - 1 1 - 0")
-
-    execute(f"float_math image_1.beta image_0.sim image_1.flat {width} 3 - - 1 1 - 0")
-
     # Make Geotiff Files
     execute(f"data2geotiff area.dem_par image_0.ls_map 5 {out_name}.ls_map.tif", uselogging=True)
     execute(f"data2geotiff area.dem_par image_0.inc_map 2 {out_name}.inc_map.tif", uselogging=True)
-    execute(f"data2geotiff area.dem_par image_1.flat 2 {out_name}.flat.tif", uselogging=True)
     execute("data2geotiff area.dem_par area.dem 2 outdem.tif", uselogging=True)
 
     gdal.Translate("{}.dem.tif".format(out_name), "outdem.tif", outputType=gdal.GDT_Int16)
@@ -290,14 +282,12 @@ def process_pol(in_file, rtc_name, out_name, pol, res, look_fact, match_flag, de
     shutil.move("{}.ls_map.tif".format(out_name), "{}/{}_ls_map.tif".format(out_dir, out_name))
     shutil.move("{}.inc_map.tif".format(out_name), "{}/{}_inc_map.tif".format(out_dir, out_name))
     shutil.move("{}.dem.tif".format(out_name), "{}/{}_dem.tif".format(out_dir, out_name))
-    if area:
-        shutil.move("{}.flat.tif".format(out_name), "{}/{}_flat_{}.tif".format(out_dir, out_name, pol))
 
     os.chdir("..")
 
 
 def process_2nd_pol(in_file, rtc_name, cpol, res, look_fact, gamma_flag, filter_flag, pwr_flag, browse_res,
-                    outfile, dem, terms, par=None, area=False, orbit_file=None):
+                    outfile, dem, terms, par=None, orbit_file=None):
     logging.info(f'Processing the {cpol} polarization')
     if cpol == "VH":
         mpol = "VV"
@@ -342,13 +332,6 @@ def process_2nd_pol(in_file, rtc_name, cpol, res, look_fact, gamma_flag, filter_
 
     os.chdir(geo_dir)
 
-    # Divide sigma0 by sin(theta) to get beta0
-    execute(f"float_math image_0.inc_map - image_1.sin_theta {width} 7 - - 1 1 - 0")
-
-    execute(f"float_math image_cal_map.mli image_1.sin_theta image_1.beta {width} 3 - - 1 1 - 0")
-
-    execute(f"float_math image_1.beta image_0.sim image_1.flat {width} 3 - - 1 1 - 0")
-
     # Make geotiff file
     if gamma_flag:
         gdal.Translate("tmp.tif", tif, metadataOptions=['Band1={}_gamma0'.format(cpol)])
@@ -369,17 +352,22 @@ def process_2nd_pol(in_file, rtc_name, cpol, res, look_fact, gamma_flag, filter_
     if not os.path.exists(out_dir):
         os.mkdir(out_dir)
 
-    execute(f"data2geotiff area.dem_par image_1.flat 2 {outfile}.flat.tif", uselogging=True)
-
     if pwr_flag:
         shutil.move(tif, "{}/{}".format(out_dir, rtc_name))
     else:
         copy_metadata(tif, "image_cal_map.mli_amp.tif")
         shutil.move("image_cal_map.mli_amp.tif", "{}/{}".format(out_dir, rtc_name))
-    if area:
-        shutil.move("{}.flat.tif".format(outfile), "{}/{}_flat_{}.tif".format(out_dir, rtc_name, cpol))
 
     os.chdir(home_dir)
+
+
+def create_area_map(mli_par, dem_seg_par, input_pix, input_map, output_name):
+    mli_width = getParameter(mli_par, 'range_samples')
+    dem_width = getParameter(dem_seg_par, 'width')
+    dem_lines = getParameter(dem_seg_par, 'nlines')
+
+    execute(f'geocode_back {input_pix} {mli_width} {input_map} area_map.pix {dem_width} {dem_lines} 2 0', uselogging=True)
+    execute(f'data2geotiff {dem_seg_par} area_map.pix 2 {output_name}', uselogging=True)
 
 
 def create_browse_images(out_name, pol, cpol, browse_res):
@@ -517,7 +505,7 @@ def rtc_sentinel_gamma(in_file,
                        par=None,
                        no_cross_pol=False,
                        smooth=False,
-                       area=False):
+                       include_area_map=False):
 
     log_file = configure_log_file()
 
@@ -554,7 +542,7 @@ def rtc_sentinel_gamma(in_file,
         out_name = get_product_name(in_file, orbit_file, res, gamma_flag, pwr_flag, filter_flag, match_flag)
 
     report_kwargs(in_file, out_name, res, dem, roi, shape, match_flag, dead_flag, gamma_flag,
-                  pwr_flag, filter_flag, looks, terms, par, no_cross_pol, smooth, area, orbit_file)
+                  pwr_flag, filter_flag, looks, terms, par, no_cross_pol, smooth, include_area_map, orbit_file)
 
     orbit_file = os.path.abspath(orbit_file)  # ingest_S1_granule requires absolute path
 
@@ -600,13 +588,16 @@ def rtc_sentinel_gamma(in_file,
     rtc_name = f'{out_name}_{pol}.tif'
     process_pol(in_file, rtc_name, out_name, pol, res, looks,
                 match_flag, dead_flag, gamma_flag, filter_flag, pwr_flag,
-                browse_res, dem, terms, par=par, area=area, orbit_file=orbit_file)
+                browse_res, dem, terms, par=par, orbit_file=orbit_file)
+
+    if include_area_map:
+        create_area_map(f'{out_name}.{pol}.mgrd.par', f'geo_{pol}/{dem}_par', f'geo_{pol}/image_1.pix', f'geo_{pol}/image_1.map_to_rdc', f'PRODUCT/{out_name}_area_map.tif')
 
     if cpol:
         rtc_name = f'{out_name}_{cpol}.tif'
         process_2nd_pol(in_file, rtc_name, cpol, res, looks,
                         gamma_flag, filter_flag, pwr_flag, browse_res,
-                        out_name, dem, terms, par=par, area=area, orbit_file=orbit_file)
+                        out_name, dem, terms, par=par, orbit_file=orbit_file)
 
     fix_geotiff_locations()
     reproject_dir(dem_type, res, prod_dir="PRODUCT")
@@ -672,7 +663,7 @@ def main():
     parser.add_argument('--output', help='base name of the output files')
     parser.add_argument("--par", help="Stack processing - use specified offset file and don't match")
     parser.add_argument("--nocrosspol", action="store_true", help="Do not process the cross pol image")
-    parser.add_argument("-a", "--area", action="store_true", help="Keep area map")
+    parser.add_argument("-a", "--include-area-map", action="store_true", help="Include area map in output package")
     args = parser.parse_args()
 
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
@@ -695,7 +686,7 @@ def main():
                        par=args.par,
                        no_cross_pol=args.nocrosspol,
                        smooth=args.smooth,
-                       area=args.area)
+                       include_area_map=args.include_area_map)
 
 
 if __name__ == "__main__":

--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -596,7 +596,7 @@ def rtc_sentinel_gamma(in_file,
 
     if include_scattering_area:
         create_area_geotiff(f'geo_{pol}/image_1.pix', f'geo_{pol}/image_1.map_to_rdc', f'{out_name}.{pol}.mgrd.par',
-                            f'geo_{pol}/{dem}_par', f'PRODUCT/{out_name}_area_map.tif')
+                            f'geo_{pol}/{dem}_par', f'PRODUCT/{out_name}_area.tif')
 
     if cpol:
         rtc_name = f'{out_name}_{cpol}.tif'

--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -362,7 +362,8 @@ def process_2nd_pol(in_file, rtc_name, cpol, res, look_fact, gamma_flag, filter_
     os.chdir(home_dir)
 
 
-def create_area_map(mli_par, dem_par, data_in, lookup_table, output_name):
+def create_area_map(data_in, lookup_table, mli_par, dem_par, output_name):
+    logging.info('Creating area map: {output_name}')
     width_in = getParameter(mli_par, 'range_samples')
     width_out = getParameter(dem_par, 'width')
     nlines_out = getParameter(dem_par, 'nlines')
@@ -593,7 +594,7 @@ def rtc_sentinel_gamma(in_file,
                 browse_res, dem, terms, par=par, orbit_file=orbit_file)
 
     if include_area_map:
-        create_area_map(f'{out_name}.{pol}.mgrd.par', f'geo_{pol}/{dem}_par', f'geo_{pol}/image_1.pix', f'geo_{pol}/image_1.map_to_rdc', f'PRODUCT/{out_name}_area_map.tif')
+        create_area_map(f'geo_{pol}/image_1.pix', f'geo_{pol}/image_1.map_to_rdc', f'{out_name}.{pol}.mgrd.par', f'geo_{pol}/{dem}_par', f'PRODUCT/{out_name}_area_map.tif')
 
     if cpol:
         rtc_name = f'{out_name}_{cpol}.tif'

--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -156,7 +156,7 @@ def reproject_dir(dem_type, res, prod_dir=None):
 
 
 def report_kwargs(in_name, out_name, res, dem, roi, shape, match_flag, dead_flag, gamma_flag,
-                  pwr_flag, filter_flag, looks, terms, par, no_cross_pol, smooth, include_area_map, orbit_file):
+                  pwr_flag, filter_flag, looks, terms, par, no_cross_pol, smooth, include_scattering_area, orbit_file):
     logging.info("Parameters for this run:")
     logging.info("    Input name                        : {}".format(in_name))
     logging.info("    Output name                       : {}".format(out_name))
@@ -177,7 +177,7 @@ def report_kwargs(in_name, out_name, res, dem, roi, shape, match_flag, dead_flag
         logging.info("    Offset file                       : {}".format(par))
     logging.info("    Process crosspol                  : {}".format(not no_cross_pol))
     logging.info("    Smooth DEM tiles                  : {}".format(smooth))
-    logging.info("    Include Area Map                  : {}".format(include_area_map))
+    logging.info("    Include Scattering Area           : {}".format(include_scattering_area))
     logging.info("    Orbit File                        : {}".format(orbit_file))
 
 
@@ -362,8 +362,8 @@ def process_2nd_pol(in_file, rtc_name, cpol, res, look_fact, gamma_flag, filter_
     os.chdir(home_dir)
 
 
-def create_area_map(data_in, lookup_table, mli_par, dem_par, output_name):
-    logging.info(f'Creating area map: {output_name}')
+def create_area_geotiff(data_in, lookup_table, mli_par, dem_par, output_name):
+    logging.info(f'Creating scattering area geotiff: {output_name}')
     width_in = getParameter(mli_par, 'range_samples')
     width_out = getParameter(dem_par, 'width')
     nlines_out = getParameter(dem_par, 'nlines')
@@ -509,7 +509,7 @@ def rtc_sentinel_gamma(in_file,
                        par=None,
                        no_cross_pol=False,
                        smooth=False,
-                       include_area_map=False):
+                       include_scattering_area=False):
 
     log_file = configure_log_file()
 
@@ -546,7 +546,7 @@ def rtc_sentinel_gamma(in_file,
         out_name = get_product_name(in_file, orbit_file, res, gamma_flag, pwr_flag, filter_flag, match_flag)
 
     report_kwargs(in_file, out_name, res, dem, roi, shape, match_flag, dead_flag, gamma_flag,
-                  pwr_flag, filter_flag, looks, terms, par, no_cross_pol, smooth, include_area_map, orbit_file)
+                  pwr_flag, filter_flag, looks, terms, par, no_cross_pol, smooth, include_scattering_area, orbit_file)
 
     orbit_file = os.path.abspath(orbit_file)  # ingest_S1_granule requires absolute path
 
@@ -594,9 +594,9 @@ def rtc_sentinel_gamma(in_file,
                 match_flag, dead_flag, gamma_flag, filter_flag, pwr_flag,
                 browse_res, dem, terms, par=par, orbit_file=orbit_file)
 
-    if include_area_map:
-        create_area_map(f'geo_{pol}/image_1.pix', f'geo_{pol}/image_1.map_to_rdc', f'{out_name}.{pol}.mgrd.par',
-                        f'geo_{pol}/{dem}_par', f'PRODUCT/{out_name}_area_map.tif')
+    if include_scattering_area:
+        create_area_geotiff(f'geo_{pol}/image_1.pix', f'geo_{pol}/image_1.map_to_rdc', f'{out_name}.{pol}.mgrd.par',
+                            f'geo_{pol}/{dem}_par', f'PRODUCT/{out_name}_area_map.tif')
 
     if cpol:
         rtc_name = f'{out_name}_{cpol}.tif'
@@ -668,7 +668,7 @@ def main():
     parser.add_argument('--output', help='base name of the output files')
     parser.add_argument("--par", help="Stack processing - use specified offset file and don't match")
     parser.add_argument("--nocrosspol", action="store_true", help="Do not process the cross pol image")
-    parser.add_argument("-a", "--include-area-map", action="store_true", help="Include area map in output package")
+    parser.add_argument("-a", "--include-scattering-area", action="store_true", help="Include a geotiff of scattering area in the output package")
     args = parser.parse_args()
 
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
@@ -691,7 +691,7 @@ def main():
                        par=args.par,
                        no_cross_pol=args.nocrosspol,
                        smooth=args.smooth,
-                       include_area_map=args.include_area_map)
+                       include_scattering_area=args.include_scattering_area)
 
 
 if __name__ == "__main__":

--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -363,13 +363,14 @@ def process_2nd_pol(in_file, rtc_name, cpol, res, look_fact, gamma_flag, filter_
 
 
 def create_area_map(data_in, lookup_table, mli_par, dem_par, output_name):
-    logging.info('Creating area map: {output_name}')
+    logging.info(f'Creating area map: {output_name}')
     width_in = getParameter(mli_par, 'range_samples')
     width_out = getParameter(dem_par, 'width')
     nlines_out = getParameter(dem_par, 'nlines')
 
     with NamedTemporaryFile() as temp_file:
-        execute(f'geocode_back {data_in} {width_in} {lookup_table} {temp_file.name} {width_out} {nlines_out} 2', uselogging=True)
+        execute(f'geocode_back {data_in} {width_in} {lookup_table} {temp_file.name} {width_out} {nlines_out} 2',
+                uselogging=True)
         execute(f'data2geotiff {dem_par} {temp_file.name} 2 {output_name}', uselogging=True)
 
 
@@ -594,7 +595,8 @@ def rtc_sentinel_gamma(in_file,
                 browse_res, dem, terms, par=par, orbit_file=orbit_file)
 
     if include_area_map:
-        create_area_map(f'geo_{pol}/image_1.pix', f'geo_{pol}/image_1.map_to_rdc', f'{out_name}.{pol}.mgrd.par', f'geo_{pol}/{dem}_par', f'PRODUCT/{out_name}_area_map.tif')
+        create_area_map(f'geo_{pol}/image_1.pix', f'geo_{pol}/image_1.map_to_rdc', f'{out_name}.{pol}.mgrd.par',
+                        f'geo_{pol}/{dem}_par', f'PRODUCT/{out_name}_area_map.tif')
 
     if cpol:
         rtc_name = f'{out_name}_{cpol}.tif'

--- a/hyp3_rtc_gamma/rtc_sentinel.py
+++ b/hyp3_rtc_gamma/rtc_sentinel.py
@@ -668,7 +668,8 @@ def main():
     parser.add_argument('--output', help='base name of the output files')
     parser.add_argument("--par", help="Stack processing - use specified offset file and don't match")
     parser.add_argument("--nocrosspol", action="store_true", help="Do not process the cross pol image")
-    parser.add_argument("-a", "--include-scattering-area", action="store_true", help="Include a geotiff of scattering area in the output package")
+    parser.add_argument("-a", "--include-scattering-area", action="store_true",
+                        help="Include a geotiff of scattering area in the output package")
     args = parser.parse_args()
 
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',


### PR DESCRIPTION
Removes code for producing flattened backscatter tifs introduced in https://github.com/ASFHyP3/hyp3-rtc-gamma/commit/ea08afac67c34c0f6064ccc57f586cc4bd03096c

Replaces the existing `--area` parameter with `--include-scattering-area`, which results in a `_area.tif` being included in the output product directory and/or zip file.

This approach avoids further patching `mk_geo_radcal` by waiting to generate the area map until after the co-pol call to `mk_geo_radcal` mode 3 has completed.

Product readme in hyp3-metadata-templates should be updated to include a description of the additional output file.

Need to confirm with Kirk whether hyp3-metadata-templates should also create an ArcGIS-compatible .xml metadata file for the area tif, and if that should include a thumbnail image.

Product guide in ASFHyP3 should be updated to reflect the additional output file.

hyp3 api and orchestration should be updated to support `include_scattering_area` as an `RTC_GAMMA` job parameter.

hyp3-testing golden set should be updated to exercise the `include_scattering_area` parameter

Need to confirm with Kirk that `include-scattering-area` will *not* be made available in HyP3 v1.

*thing I forgot here*